### PR TITLE
Update ecma keyword detection regex to not misfire on strings containing periods

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -1,9 +1,9 @@
 const stringRE = /'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*\$\{|\}(?:[^`\\]|\\.)*`|`(?:[^`\\]|\\.)*`/g
-const ecmaKeywordsRE = new RegExp('\\b' + (
+const ecmaKeywordsRE = new RegExp('(?<!\\.)\\b' + (
   'delete,typeof,instanceof,void,do,if,for,let,new,try,var,case,else,with,await,break,catch,class,const,' +
   'alert,eval,super,throw,while,yield,delete,export,import,return,switch,default,' +
   'extends,finally,continue,debugger,function,arguments'
-).split(',').join('\\b|\\b') + '\\b')
+).split(',').join('\\b(?!\\.)|(?<!\\.)\\b') + '\\b(?!\\.)')
 
 function warn (msg, err) {
   if (typeof console !== 'undefined') {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -23,3 +23,9 @@ it('ecmascript keyword should not be evaluate', () => {
   expect(status).toEqual('ng')
   expect(value).toEqual(undefined)
 })
+
+it('string literal containing period delimited ecmascript keywords should evaluate', () => {
+  const { status, value } = evaluateValue(`'new.alert.import'`)
+  expect(status).toEqual('ok')
+  expect(value).toEqual('new.alert.import')
+})


### PR DESCRIPTION
Addresses https://github.com/intlify/vue-i18n-extensions/issues/28