### PR TITLE
Added whitespace trim to handle oddly formatted vue templates

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -48,7 +48,7 @@ function evaluateValue (expression) {
   if (!expression.match(stringRE)) { return ret }
 
   try {
-    const val = (new Function(`return ${expression}`))()
+    const val = (new Function(`return ${expression.trim()}`))()
     ret.status = 'ok'
     ret.value = val
   } catch (e) { }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -29,3 +29,11 @@ it('string literal containing period delimited ecmascript keywords should evalua
   expect(status).toEqual('ok')
   expect(value).toEqual('new.alert.import')
 })
+
+it('string literal containing whitespace and newline keywords should evaluate', () => {
+  const { status, value } = evaluateValue(`
+      'hello'
+  `)
+  expect(status).toEqual('ok')
+  expect(value).toEqual('hello')
+})


### PR DESCRIPTION
Ran into this issue when adding vue-i18n to a project already using prettier-js for code formatting. In highly nested html trees `v-t ` directives would sometimes get formatted to:

```javascript
<span v-t="
    'translation key'
">
```

This PR addresses these scenarios




