### PR TITLE
Add parallel: false to vue-loader example

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ module.exports = {
       // ...
     ]
   },
-  plugins: [new VueLoaderPlugin()]
+  plugins: [new VueLoaderPlugin()],
+  parallel: false // the compilerOptions.directiveTransforms are not serializable
 }
 ```
 


### PR DESCRIPTION
In a parallel build, the non-serializable directiveTransforms would quietly be dropped.

---

I’m not 100% sure if this is correct. I found (after painful debugging) that I had to add `parallel: false` to my `vue.config.js` to make `directiveTransforms` work at all, and since this repository seems to be one of the very few places on the internet that shows how to use `directiveTransforms`, I thought it would be good to add this information here. However, I’m not sure about the difference between vue-loader and vue-cli, and which of the two is being demonstrated in the README; it’s possible that the `parallel` option actually doesn’t belong in this example.