### PR TITLE
ci: add spell check action using `typos`

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,21 @@
+name: Typos
+on:
+  pull_request:
+    branches-ignore:
+      - gh-pages
+      - releases/**
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  run:
+    name: Spell check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Spell check
+        uses: crate-ci/typos@v1.21.0

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ console.log(await renderToString(app))
 
 ### Pre-Translation with using `v-t` custom directive
 
-You can pre-translation i18n locale messsages of vue-i18n.
+You can pre-translation i18n locale messages of vue-i18n.
 
 > :warning: NOTE: Only the scope of global i18n locale messages can be pre-translated !!
 
@@ -139,7 +139,7 @@ console.log(code)
 */
 ```
 
-The following configration example of `vue-loader`:
+The following configuration example of `vue-loader`:
 
 ```js
 const { VueLoaderPlugin } = require('vue-loader')

--- a/example/index.html
+++ b/example/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>vue-i18n-extention example</title>
+    <title>vue-i18n-extension example</title>
   </head>
   <body>
     <div id="app">

--- a/src/report.ts
+++ b/src/report.ts
@@ -31,10 +31,10 @@ export const enum ReportCodes {
 const ReportMessages: { [code: number]: string } = {
   [ReportCodes.UNEXPECTED_DIRECTIVE_EXPRESSION]: `Unexpected directive expression: {0}`,
   [ReportCodes.NOT_SUPPORTED]: `Not supported transform: {0}`,
-  [ReportCodes.FAILED_VALUE_EVALUATION]: `Failed valu evaluation: {0}`,
+  [ReportCodes.FAILED_VALUE_EVALUATION]: `Failed value evaluation: {0}`,
   [ReportCodes.REQUIRED_PARAMETER]: `Required parameter: {0}`,
   [ReportCodes.INVALID_PARAMETER_TYPE]: `Required parameter: {0}`,
-  [ReportCodes.NOT_SUPPORTED_PRESERVE]: `Not supportted 'preserve': {0}`,
+  [ReportCodes.NOT_SUPPORTED_PRESERVE]: `Not supported 'preserve': {0}`,
   [ReportCodes.OVERRIDE_ELEMENT_CHILDREN]: `v-t will override element children: {0}`
 }
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -225,7 +225,7 @@ export function transformVTDirective<
         return { props: [] }
       }
     } else if (isCompoundExpressionNode(exp)) {
-      const content = exp.children.map(mapNodeContentHanlder).join('')
+      const content = exp.children.map(mapNodeContentHandler).join('')
       const code = generateTranslationCode(
         context,
         mode,
@@ -280,7 +280,7 @@ function isConstant(node: SimpleExpressionNode): boolean {
   }
 }
 
-function mapNodeContentHanlder(
+function mapNodeContentHandler(
   value:
     | string
     | symbol
@@ -296,14 +296,14 @@ function mapNodeContentHanlder(
   } else if (isSimpleExpressionNode(value)) {
     return value.content
   } else if (isCompoundExpressionNode(value)) {
-    return value.children.map(mapNodeContentHanlder).join('')
+    return value.children.map(mapNodeContentHandler).join('')
   } else if (isText(value)) {
     if (isString(value.content)) {
       return value.content
     } else if (isSimpleExpressionNode(value.content)) {
       return value.content.content
     } else if (isCompoundExpressionNode(value.content)) {
-      return value.content.children.map(mapNodeContentHanlder).join('')
+      return value.content.children.map(mapNodeContentHandler).join('')
     } else {
       return ''
     }


### PR DESCRIPTION
Adds a github action that spell checks all files, see https://github.com/intlify/vue-i18n-extensions/actions/runs/9131004657/job/25109252903?pr=205 for an example of what it looks like.