### PR TITLE
fix: drop preserve checking logic

### DIFF
--- a/src/report.ts
+++ b/src/report.ts
@@ -22,7 +22,6 @@ export const enum ReportCodes {
   FAILED_VALUE_EVALUATION,
   REQUIRED_PARAMETER,
   INVALID_PARAMETER_TYPE,
-  NOT_SUPPORTED_PRESERVE,
   OVERRIDE_ELEMENT_CHILDREN,
   NOT_RESOLVED_COMPOSER,
   UNEXPECTED_ERROR,
@@ -36,7 +35,6 @@ const ReportMessages: { [code: number]: string } = {
   [ReportCodes.FAILED_VALUE_EVALUATION]: `Failed value evaluation: {0}`,
   [ReportCodes.REQUIRED_PARAMETER]: `Required parameter: {0}`,
   [ReportCodes.INVALID_PARAMETER_TYPE]: `Required parameter: {0}`,
-  [ReportCodes.NOT_SUPPORTED_PRESERVE]: `Not supported 'preserve': {0}`,
   [ReportCodes.OVERRIDE_ELEMENT_CHILDREN]: `v-t will override element children: {0}`,
   [ReportCodes.NOT_RESOLVED_COMPOSER]: `Not resolved vue-i18n composer: {0}`,
   [ReportCodes.UNEXPECTED_ERROR]: `Unexpected error: {0}`

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -169,13 +169,6 @@ export function transformVTDirective<
       node.children.length = 0
     }
 
-    if (dir.modifiers.includes('preserve')) {
-      report(ReportCodes.NOT_SUPPORTED_PRESERVE, {
-        args: [node.loc.source || ''],
-        loc: node.loc
-      })
-    }
-
     if (isSimpleExpressionNode(exp)) {
       if (isConstant(exp) && i18nInstance) {
         const { status, value } = evaluateValue(exp.content)

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -6,15 +6,6 @@ import { transformVTDirective } from '../src/transform'
 import { getReportMessage, ReportCodes } from '../src/report'
 import { mount } from './helper'
 
-function getMessage(code: ReportCodes, ...args: unknown[]) {
-  return `[vue-i18n-extensions] ${getReportMessage(code, ...args)}`
-}
-
-let spyWarn: ReturnType<typeof vi.spyOn>
-beforeEach(() => {
-  spyWarn = vi.spyOn(global.console, 'warn') as ReturnType<typeof vi.spyOn>
-})
-
 afterEach(() => {
   // vi.clearAllMocks()
   // vi.resetAllMocks()
@@ -75,22 +66,6 @@ describe('binding', () => {
     expect(code).toMatchSnapshot(source)
     expect(ast).toMatchSnapshot(source)
   })
-})
-
-test('preserve modifier', () => {
-  spyWarn.mockImplementation(() => {})
-
-  const transformVT = transformVTDirective()
-  const source = `<div v-t.preserve="'hello'"/>`
-  const { code, ast } = compile(source, {
-    mode: 'function',
-    hoistStatic: false,
-    prefixIdentifiers: true,
-    directiveTransforms: { t: transformVT }
-  })
-  expect(code).toMatchSnapshot(source)
-  expect(ast).toMatchSnapshot(source)
-  expect(spyWarn.mock.calls[0][0]).toEqual(getMessage(ReportCodes.NOT_SUPPORTED_PRESERVE, source))
 })
 
 test('no specify', () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/vue-i18n-extensions/blob/next/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
The `preserve` modifier is no longer supported in vue-i18n v10.

https://vue-i18n.intlify.dev/guide/migration/breaking10.html#drop-preserve-modifier-codes-on-v-t-directive

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
