### PR TITLE
fix(deps): remove `@intlify/shared` and `vue-i18n` from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/parser": "^7.24.6",
-    "@intlify/shared": "^10.0.0",
-    "@vue/compiler-dom": "^3.2.45",
-    "vue-i18n": "^10.0.0"
+    "@vue/compiler-dom": "^3.2.45"
   },
   "devDependencies": {
     "@babel/types": "^7.24.6",


### PR DESCRIPTION
### Description

Hey! 👋

PR #305 fixed the `peerDependencies` to accept v11 — nice. But `@intlify/shared` and `vue-i18n` are still listed in `dependencies` with `^10.0.0`, which means npm installs a separate v10 copy alongside the consumer's v11. This triggers a deprecation warning on every `npm install`:

```
npm warn deprecated vue-i18n@10.0.8: v9 and v10 no longer supported. please migrate to v11.
```

Both packages should only be in `peerDependencies` (where they already are). Here's why it's safe to remove them from `dependencies`:

- **`vue-i18n`** — every import in the source is `import type` (in `transform.ts`). Zero runtime usage. The consumer provides the `i18n` instance via `options.i18n`.
- **`@intlify/shared`** — the runtime utilities used (`isString`, `isNumber`, `format`, `hasOwn`, etc.) are always available transitively through the consumer's `vue-i18n` installation.

This is the standard pattern — these are peer dependencies, not direct ones.

### Linked Issues

- Related to #300
- Follow-up to #305

### Additional context

Once this is released, `@intlify/unplugin-vue-i18n` should bump its `@intlify/vue-i18n-extensions` dependency to pick up the fix (Renovate will probably handle that automatically).